### PR TITLE
Removes logo from UVP

### DIFF
--- a/app/_includes/sections/uvp.html
+++ b/app/_includes/sections/uvp.html
@@ -1,20 +1,15 @@
 <section class="Layout">
   <div class="Scene">
-    <div class="Layout-defaultThenLargeMargin"></div>
-    <div class="Container Container--twoColumn">
-      <div class="Container-column">
-        <div class="ContentFormatter ContentFormatter--centerThenAlignRight">
-          <object class="Logo" type="image/svg+xml" data="/img/logo.svg"></object>
+    <div class="Layout-defaultThenLargeMarginWithHeader"></div>
+    <div class="Container">
+      <div class="Container-largeColumn">
+        <div class="ContentFormatter ContentFormatter--center">
+          <p class="Heading Heading--large">
+            Aprende a programar e torna-te um super-herói em 9 semanas!
+          </p>
+          <div class="Layout-defaultMargin"></div>
         </div>
-      </div>
-      <div class="Container-column">
-        <p class="Heading Heading--uvp">
-          Aprende a programar e torna-te um super-herói em 9 semanas
-        </p>
-        <div class="Layout-smallMargin"></div>
-        <p>Na Creators School não importa de onde vens, importa para onde queres ir. Agarra esta oportunidade para mudares o teu futuro.</p>
-        <div class="Layout-smallMargin"></div>
-        <a class="ButtonPrimary ButtonPrimary--mobileCentered" href="{{ site.data.links.registration }}">Inscreve-te já</a>
+        <a class="ButtonPrimary" href="{{ site.data.links.registration }}">Inscreve-te já</a>
       </div>
     </div>
   </div>

--- a/app/_scss/_theme_vars.scss
+++ b/app/_scss/_theme_vars.scss
@@ -41,6 +41,9 @@ $Theme-spacing-large: 100px;
 $Theme-spacing-small: 25px;
 $Theme-spacing-xSmall: 10px;
 
+// Nav
+$Theme-navbar-height: 60px;
+
 // Typography
 $Theme-typography-fontWeight-bold: 900;
 $Theme-typography-fontWeight-medium: 500;
@@ -51,7 +54,7 @@ $Theme-font-sizes: (
     sansSerif: (
       small: (
         font-size: 10px,
-        line-height: 1.625 // 26px / 16px
+        line-height: 1.625
       ),
       base: (
         font-size: 14px,
@@ -64,6 +67,10 @@ $Theme-font-sizes: (
       veryLarge: (
         font-size: 30px,
         line-height: 1.55
+      ),
+      heading: (
+        font-size: 25px,
+        line-height: 1.55
       )
     )
   ),
@@ -71,7 +78,7 @@ $Theme-font-sizes: (
     sansSerif: (
       small: (
         font-size: 10px,
-        line-height: 1.625 // 26px / 16px
+        line-height: 1.625
       ),
       base: (
         font-size: 16px,
@@ -84,6 +91,10 @@ $Theme-font-sizes: (
       veryLarge: (
         font-size: 34px,
         line-height: 1.55
+      ),
+      heading: (
+        font-size: 48px,
+        line-height: 1.35
       )
     )
   )

--- a/app/_scss/components/_anchor.sass
+++ b/app/_scss/components/_anchor.sass
@@ -1,4 +1,5 @@
-$Anchor-offset: 74px
+@import '../theme_vars'
+$Anchor-offset: $Theme-navbar-height
 
 .Anchor
   padding-top: $Anchor-offset

--- a/app/_scss/components/_container.scss
+++ b/app/_scss/components/_container.scss
@@ -43,6 +43,15 @@
   padding: 0 $Theme-spacing-small;
 }
 
+.Container-largeColumn {
+  flex: 1 0 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 900px;
+  padding: 0 $Theme-spacing-small;
+}
+
 .Container.Container--twoColumn {
   .Container-column + .Container-column {
     margin-top: $Theme-spacing-small;

--- a/app/_scss/components/_heading.scss
+++ b/app/_scss/components/_heading.scss
@@ -32,6 +32,7 @@
   color: $Theme-color-white;
 }
 
-.Heading.Heading--uvp {
+.Heading.Heading--large {
+  @include font-properties(heading);
   text-transform: none;
 }

--- a/app/_scss/components/_layout.scss
+++ b/app/_scss/components/_layout.scss
@@ -59,6 +59,14 @@
   }
 }
 
+.Layout-defaultThenLargeMarginWithHeader {
+  padding-bottom: calc(#{$Theme-spacing-default} + #{$Theme-navbar-height});
+
+  @include media(">=tablet") {
+    padding-bottom: calc(#{$Theme-spacing-large} + #{$Theme-navbar-height});
+  }
+}
+
 .Layout-desktopOnly {
   display: none;
 

--- a/app/_scss/components/_nav.sass
+++ b/app/_scss/components/_nav.sass
@@ -1,3 +1,5 @@
+@import '../theme_vars'
+$Nav-height: $Theme-navbar-height
 $Nav-opaque-bg-color: white
 
 .Nav
@@ -8,6 +10,7 @@ $Nav-opaque-bg-color: white
   flex-wrap: wrap
   align-content: flex-start
   width: 100%
+  height: $Nav-height
   justify-content: space-between
   padding: 12px 30px
   transition: all 0.3s
@@ -38,6 +41,7 @@ $Nav-opaque-bg-color: white
   .Nav-mobileBurger
     display: none
   .Nav-menu
-    display: block
+    display: flex
+    align-items: center
     height: 100%
 


### PR DESCRIPTION
Centers the rest of the content and takes the navbar into account for
the top margin of that content.

The navbar has a fixes height, so that it is easier to reason about it.

Fixes #3
